### PR TITLE
Double qoute the ifc_ctl_sudoers content to have "\n" workable.

### DIFF
--- a/manifests/common/plumgrid.pp
+++ b/manifests/common/plumgrid.pp
@@ -14,7 +14,7 @@ class openstack::common::plumgrid {
     owner   => root,
     group   => root,
     mode    => '0440',
-    content => 'nova ALL=(root) NOPASSWD: /opt/pg/bin/ifc_ctl_pp *\n',
+    content => "nova ALL=(root) NOPASSWD: /opt/pg/bin/ifc_ctl_pp *\n",
   }
 
   openstack::resources::firewall { 'Nova API': port => '8774', }


### PR DESCRIPTION
Ticket: [SOL-536]
Signed-off-by: salmank salmank@plumgrid.com
