### PR TITLE
fix for SOL-659

### DIFF
--- a/manifests/common/neutron.pp
+++ b/manifests/common/neutron.pp
@@ -46,8 +46,6 @@ class openstack::common::neutron {
     enabled             => $is_controller,
     sync_db             => $is_controller,
     mysql_module        => '2.2',
-    api_workers         => '0',
-    rpc_workers         => '0',
   }
 
   if $::osfamily == 'redhat' {


### PR DESCRIPTION
api_workers and rpc_workers were set to 0. Setting them back to number of cpu cores available.
